### PR TITLE
add cargo compiler by-default

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ flymake-rust.el
 ==========================
 
 An Emacs flymake handler for syntax-checking Rust source code
-using `rustc`.
+using `cargo` or `rustc`.
 
 Installation
 =============
@@ -20,6 +20,14 @@ Add the following to your emacs init file:
 
     (require 'flymake-rust)
     (add-hook 'rust-mode-hook 'flymake-rust-load)
+
+Checker uses `cargo` by-default. If you want to use `rustc` compiler,
+you must add following strings:
+
+    (setq flymake-rust-use-cargo nil)
+    (require 'flymake-rust)
+    (add-hook 'rust-mode-hook 'flymake-rust-load)
+
 
 [marmalade]: http://marmalade-repo.org
 [melpa]: http://melpa.milkbox.net

--- a/flymake-rust.el
+++ b/flymake-rust.el
@@ -10,6 +10,9 @@
 ;;   (require 'flymake-rust)
 ;;   (add-hook 'rust-mode-hook 'flymake-rust-load)
 ;;
+;; If you want to use rustc compiler, you must add following string:
+;;   (setq flymake-rust-use-cargo 1)
+;;
 ;; Uses flymake-easy, from https://github.com/purcell/flymake-easy
 
 ;;; Code:
@@ -20,13 +23,23 @@
   '(("^\\(.*.rs\\):\\([0-9]+\\):[0-9]+: [0-9]+:[0-9]+ [a-z]+: \\(.*\\)$" 1 2 nil 3))
   '(("^\\(.*.rs\\):\\([0-9]+\\) \\(.*\\)$" 1 2 nil 3)))
 
-(defvar flymake-rust-executable "rustc"
-  "The rust executable to use for syntax checking.")
+(setq-default flymake-rust-use-cargo 1)
+
+(if flymake-rust-use-cargo
+    (defvar flymake-rust-executable "cargo"
+      "The rust executable to use for syntax checking.")
+    (defvar flymake-rust-executable "rustc"
+      "The rust executable to use for syntax checking.")
+)
 
 ;; Invoke rust "--parse-only" to get syntax checking
 (defun flymake-rust-command (filename)
   "Construct a command that flymake can use to check rust source."
-(list flymake-rust-executable "--no-trans" filename))
+  (if flymake-rust-use-cargo
+      (list flymake-rust-executable "build")
+      (list flymake-rust-executable "--no-trans" filename)
+      )
+  )
 
 ;; Load rust-flymake
 (defun flymake-rust-load ()


### PR DESCRIPTION
In my opinion, it's better to use `cargo build` command for syntax-checking for projects with many files.
